### PR TITLE
Add welcome command

### DIFF
--- a/slack-library-bot/commands/welcome.rb
+++ b/slack-library-bot/commands/welcome.rb
@@ -1,0 +1,13 @@
+module SlackLibraryBot
+  module Commands
+    # Print on-demand welcome information
+    # This is largely for testing purposes
+    # The primary need for this feature is when new ysers join the organization
+    class Welcome < SlackRubyBot::Commands::Base
+      command 'welcome' do |client, data, _match|
+        client.say(text: SlackLibraryBot::Web.settings.commands['new-user'],
+                   channel: data.channel)
+      end
+    end
+  end
+end

--- a/slack_library_bot.rb
+++ b/slack_library_bot.rb
@@ -1,6 +1,7 @@
 require 'slack-ruby-bot'
 require 'slack-library-bot/commands/about'
 require 'slack-library-bot/commands/rooms'
+require 'slack-library-bot/commands/welcome'
 require 'slack-library-bot/commands/hours'
 require 'slack-library-bot/commands/service_desk'
 require 'slack-library-bot/helpers/daily_hours'

--- a/spec/slack-library-bot/commands/welcome_spec.rb
+++ b/spec/slack-library-bot/commands/welcome_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe SlackLibraryBot::Commands::ServiceDesk do
+  let(:welcome_info) { SlackLibraryBot::Web.settings.commands['new-user'] }
+
+  it 'responds to -> welcome' do
+    expect(message: "#{SlackRubyBot.config.user} welcome", channel: 'channel')
+      .to respond_with_slack_message(welcome_info)
+  end
+end


### PR DESCRIPTION
This command is largely in place for testing purposes. The information
is targeted towards new users and will be shown when a user joins the
team, fired via the `team_join` event. The handling for that is already
in place via `server.rb`