### PR TITLE
Syslogger + systemd/journald for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ ops/ansible.cfg
 ops/hosts
 ops/*.retry
 ops/*.log
+ops/.vault_pass.txt
 *.log
 
 fugitive*

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'puma', '~> 3.12'
 gem 'sinatra', '~> 2.0'
 gem 'sinatra-contrib'
 gem 'slack-ruby-bot', '~> 0.10'
+gem 'syslogger', '~> 1.6'
 
 group :development, :test do
   gem 'byebug', '~> 10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       gli
       hashie
       websocket-driver
+    syslogger (1.6.5)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     thor (0.19.4)
@@ -169,6 +170,7 @@ DEPENDENCIES
   sinatra (~> 2.0)
   sinatra-contrib
   slack-ruby-bot (~> 0.10)
+  syslogger (~> 1.6)
   timecop (~> 0.9)
   vcr (~> 4.0)
   webmock (~> 3.2)

--- a/config.ru
+++ b/config.ru
@@ -4,7 +4,7 @@ require 'slack_library_bot'
 require 'web'
 require 'syslogger'
 
-# Will send all messages to the local0 facility, adding the process id in the message
+# Will send all messages to the local7 facility, adding the process id in the message
 SlackRubyBot::Client.logger = Syslogger.new('dewey', Syslog::LOG_PID, Syslog::LOG_LOCAL7)
 SlackRubyBot::Client.logger.level = Logger::WARN
 

--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,10 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'slack_library_bot'
 require 'web'
+require 'syslogger'
 
+# Will send all messages to the local0 facility, adding the process id in the message
+SlackRubyBot::Client.logger = Syslogger.new('dewey', Syslog::LOG_PID, Syslog::LOG_LOCAL7)
 SlackRubyBot::Client.logger.level = Logger::WARN
 
 Thread.abort_on_exception = true

--- a/ops/deploy.yml
+++ b/ops/deploy.yml
@@ -60,7 +60,6 @@
         template:
           src: puma.service.j2
           dest: /etc/systemd/system/puma.service
-          mode: 0755
 
       - name: Reload systemd daemon
         become: yes

--- a/ops/templates/puma.rb.j2
+++ b/ops/templates/puma.rb.j2
@@ -11,7 +11,8 @@ bind 'tcp://0.0.0.0:9292'
 
 pidfile '{{ ansistrano_deploy_to }}/shared/tmp/pids/puma.pid'
 state_path '{{ ansistrano_deploy_to }}/shared/tmp/pids/puma.state'
-stdout_redirect '{{ ansistrano_deploy_to }}/shared/log/stdout', '{{ ansistrano_deploy_to }}/shared/log/stderr'
+# Log to syslog. 3rd parameter sets append == true
+stdout_redirect '/var/log/messages', '/var/log/messages', true
 
 on_restart do
 # Code to run before doing a restart. This code should

--- a/ops/templates/puma.rb.j2
+++ b/ops/templates/puma.rb.j2
@@ -11,8 +11,8 @@ bind 'tcp://0.0.0.0:9292'
 
 pidfile '{{ ansistrano_deploy_to }}/shared/tmp/pids/puma.pid'
 state_path '{{ ansistrano_deploy_to }}/shared/tmp/pids/puma.state'
-# Log to syslog. 3rd parameter sets append == true
-stdout_redirect '/var/log/messages', '/var/log/messages', true
+# No explicit logging, should default to systemd service / journald
+# stdout_redirect '/var/log/messages', '/var/log/messages', true
 
 on_restart do
 # Code to run before doing a restart. This code should

--- a/ops/templates/puma.service.j2
+++ b/ops/templates/puma.service.j2
@@ -17,7 +17,7 @@ User={{ bot_user }}
 WorkingDirectory={{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}
 
 # Helpful for debugging socket activation, etc.
-Environment="PUMA_DEBUG=1"
+# Environment="PUMA_DEBUG=1"
 
 # The command to start Puma. This variant uses a binstub generated via
 # `bundle binstubs puma --path ./sbin` in the WorkingDirectory


### PR DESCRIPTION
The current implementation was writing all puma logs to explicit log files.

This set of changes instead allows the web server, puma, to delegate all logs at the webserver level to the systemd service, which makes them available via `journalctl`. An example of reading the current journal for the puma service is `sudo journalctl --unit=puma.service`

I've still added the `syslogger` gem and wired that up for local app logging, but there should be very little, if any, output from this because Sinatra is really just a very small wrapper in this case, Puma is managing all the heavy lifting.